### PR TITLE
[sc-119] - Add owl ui to scrowl

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -29,6 +29,7 @@
     "@electron-forge/maker-squirrel": "^6.0.0-beta.61",
     "@electron-forge/maker-zip": "^6.0.0-beta.61",
     "@electron-forge/plugin-webpack": "6.0.0-beta.61",
+    "@owlui/components": "^0.0.18",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^4.0.1",

--- a/apps/electron/src/index.tsx
+++ b/apps/electron/src/index.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { Default as Button } from '@owlui/button';
+import { Default as TextField } from '@owlui/textfield';
 
 const App = (): JSX.Element => {
   return (
     <div className="App">
+      <Button appearance="Primary">OwlUI Button</Button>
+      <TextField appearance="Primary"></TextField>
       <h1>Hello from React!</h1>
     </div>
   );

--- a/apps/electron/tsconfig.json
+++ b/apps/electron/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "tsconfig/electron.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/tsconfig/electron.json
+++ b/packages/tsconfig/electron.json
@@ -17,5 +17,5 @@
       "*": ["node_modules/*"]
     }
   },
-  "include": ["src/**/*.ts"]
+  "include": ["./src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,92 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@owlui/button@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/button/-/button-0.0.18.tgz#54609dfb5047f42884b6b424550ba1d513120fac"
+  integrity sha512-LYDpZs6A9pczI+fGv8n2vBB0s+/T3hzoIJLOVZckL6jh9gHBn7W1QiVEFuSbGwzF85dKfdSLzMhrxRl4yGyrAA==
+  dependencies:
+    "@owlui/theme" "^0.0.18"
+    "@owlui/typings" "^0.0.18"
+    "@owlui/utils" "^0.0.18"
+
+"@owlui/card@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/card/-/card-0.0.18.tgz#5f547159ebbdc6aa1a3cf9e91f673a7ee8d562b9"
+  integrity sha512-3u2MC9XPOsMo8Ki4Yb2yM5Rr3aByupW2M09I0Rkmp4mIcPSSV1NnC+a6W0UDRvphZFyWkczDWzRu4YvgNuI0JA==
+  dependencies:
+    "@owlui/typings" "^0.0.1"
+    "@owlui/utils" "^0.0.18"
+
+"@owlui/components@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/components/-/components-0.0.18.tgz#b57ecb346dab0e722d7d292b501afb53a95ce7db"
+  integrity sha512-LUIF76k+Gf3Ipbx7fDTP8iArKkNRJZ4OENNOty7LEyNFbB5Ya1HEg+SdidaRbGJWW5zWKq7nHDR1QAhzUNwiWw==
+  dependencies:
+    "@owlui/button" "^0.0.18"
+    "@owlui/card" "^0.0.18"
+    "@owlui/icons" "^0.0.18"
+    "@owlui/navigationdrawer" "^0.0.18"
+    "@owlui/table" "^0.0.18"
+    "@owlui/textfield" "^0.0.18"
+    "@owlui/theme" "^0.0.18"
+    "@owlui/typings" "^0.0.18"
+    "@owlui/utils" "^0.0.18"
+
+"@owlui/icons@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/icons/-/icons-0.0.18.tgz#798634e6b4fdf867ade322f408c6a9ee3314ab4c"
+  integrity sha512-I0KVRobDw9KwiIdaPumBTSHpiuXzTGzefEBJJkP9NoYbBZ1WJRJ9QyYeqD51uINm8UUKNFb59ZX0DuLtdz+EKQ==
+  dependencies:
+    "@owlui/typings" "^0.0.1"
+
+"@owlui/navigationdrawer@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/navigationdrawer/-/navigationdrawer-0.0.18.tgz#cecf55aaba7685fa4a82f9ba75d694707e2dbd82"
+  integrity sha512-ha/CKAQG0bvQqya7izieEIW7vMP9nyO3WRPfD0vM0tAh8ssNoaAbKul+J2Gs9omRPnxNaa2h1YrlL6LQpuPJXw==
+  dependencies:
+    "@owlui/typings" "^0.0.1"
+    "@owlui/utils" "^0.0.18"
+
+"@owlui/table@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/table/-/table-0.0.18.tgz#64ab1b2c6d1f28fe27594e6e0e0bde0731957c59"
+  integrity sha512-GwnAOHnh4tcHfPLLQbdXICZoPHN0TKR253kwO9nyEJcJjR7DxxqDj6EtaDrq6I3QhCnoVHHezBZgGEDx7GTmgg==
+  dependencies:
+    "@owlui/typings" "^0.0.1"
+    "@owlui/utils" "^0.0.18"
+
+"@owlui/textfield@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/textfield/-/textfield-0.0.18.tgz#c99f61580788bd650105c874a376965b8a7544b5"
+  integrity sha512-v4S/PD4pUq2a+goLOJJV+NL8Q2whzn806RmgT3ANVFFT8BFplOqwTs3NExlfES2bwEMCktK8NQJj/NDZ/3qokA==
+  dependencies:
+    "@owlui/theme" "^0.0.18"
+    "@owlui/typings" "^0.0.18"
+
+"@owlui/theme@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/theme/-/theme-0.0.18.tgz#1a018d37a433b9d03e51b0bf401686b873ccee13"
+  integrity sha512-Iw/jAmdX+RTgim+nU/1g1jslZ33RriNSG5r7iIblBxWOjvFi+eAmQaZwFlEzwTCnMVOI8fY7CXmeu9ueEocT7w==
+  dependencies:
+    "@owlui/typings" "^0.0.1"
+    material-design-icons "^3.0.1"
+
+"@owlui/typings@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@owlui/typings/-/typings-0.0.1.tgz#713a45a5eef4d9ba10c8d3963079da40f2f4c127"
+  integrity sha512-BruOjZvXTTSUOr/+uA2OnU73yjsvpjTB/O971uTqbx77HONI52d8dSEv5xDqxrMM2+mxZOUjb4hRkAqJhQXylw==
+
+"@owlui/typings@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/typings/-/typings-0.0.18.tgz#2bd3730ded07dbaaaa66025a5e9b4c0b2800c490"
+  integrity sha512-YOqS6Y/3Y9TF9olDk3HVFLsmX8qeL5D/JtU4IlIZd0Isksxd6LBCSOjU4rq2vf5j7yF4/OiGr1y3ITliwcDnCQ==
+
+"@owlui/utils@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@owlui/utils/-/utils-0.0.18.tgz#ac6090801b3bf3117b2b4cd4d3af9f154bc4c614"
+  integrity sha512-U/J5ZmXn/C0uAQ8J1PxnE9XdDk+cyc20v2a98rn0ivsJH/mm1ODLY9UPCoRu6wSU+x5qz8gJNIA27CqUpv62gg==
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"
@@ -7804,6 +7890,11 @@ matcher@^3.0.0:
   integrity sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==
   dependencies:
     escape-string-regexp "^4.0.0"
+
+material-design-icons@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/material-design-icons/-/material-design-icons-3.0.1.tgz#9a71c48747218ebca51e51a66da682038cdcb7bf"
+  integrity sha1-mnHEh0chjrylHlGmbaaCA4zct78=
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
### Short summary
Add OwlUI to the project and ensure the components are loaded properly.

The Docker image has been updated with the new module.

---

### Test steps

1. Run `make start startOver=true` to use the new Docker image and start the project
2. You will see a button and a text field components, both are OwlUI components as you can check out in the `apps/electron/src/index.tsx` file
