### PR TITLE
UPDATE - npm doesn't install workspace packages correctly

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,8 +26,10 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Install Lerna
+        run: npm install lerna
       - name: Install Dependencies
-        run: npm install
+        run: lerna bootstrap
       - name: Deploy Latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,10 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Install Lerna
+        run: npm install lerna
       - name: Install Dependencies
-        run: npm install
+        run: lerna bootstrap
       - name: Publish Distributables
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When the local packages are namespaced (e.i. @scrowl/<package-name>), npm install will fetch from the remote npm registry. Using `lerna bootstrap` allows for packages to be installed correctly.
