### PR TITLE
UPDATE - added example listener for preference open event

### DIFF
--- a/apps/authoring/src/main/services/menu/templates/service-menu-items-app.ts
+++ b/apps/authoring/src/main/services/menu/templates/service-menu-items-app.ts
@@ -4,26 +4,16 @@ import { MenuItemEventsApp } from '../service-menu.types';
 
 const separator: MenuItemConstructorOptions = { type: 'separator' };
 
-const aboutHandler = () => {
-  console.log('Open about Scrowl window...');
-};
-
-const preferencesHandler = () => {
-  console.log('Open preferences window...');
-};
-
 export const EVENTS: MenuItemEventsApp = {
   aboutOpen: {
     id: 'about-open',
     name: 'menu/about/open',
-    type: 'on',
-    fn: aboutHandler,
+    type: 'send',
   },
   preferencesOpen: {
     id: 'preferences-open',
     name: 'menu/preferences/open',
-    type: 'on',
-    fn: preferencesHandler,
+    type: 'send',
   },
 };
 

--- a/apps/authoring/src/renderer/components/app/comp-app.tsx
+++ b/apps/authoring/src/renderer/components/app/comp-app.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router-dom';
 import * as styles from './styles/comp-app.module.scss';
 import { pageRoutes } from './comp-app-routes';
+import { Menu } from '../../services';
 import { Home, PageNavProps } from '../../pages';
 import { TitleBar } from './elements';
 
@@ -40,6 +41,10 @@ export const App = () => {
 
   //   setTitlesList(newTitles);
   // };
+
+  Menu.App.onPreferenceOpen(ev => {
+    console.log('preference open event', ev);
+  });
 
   return (
     <Router>

--- a/apps/authoring/src/renderer/services/menu/index.ts
+++ b/apps/authoring/src/renderer/services/menu/index.ts
@@ -1,2 +1,3 @@
 export * as Global from './service-menu-global';
 export * as File from './service-menu-file';
+export * as App from './service-menu-app';

--- a/apps/authoring/src/renderer/services/menu/service-menu-app.ts
+++ b/apps/authoring/src/renderer/services/menu/service-menu-app.ts
@@ -1,0 +1,22 @@
+import { requester } from '..';
+import { MenuEventsAppApi } from '../../../main/services/menu';
+
+export const ENDPOINTS: MenuEventsAppApi = {
+  aboutOpen: 'menu/about/open',
+  preferencesOpen: 'menu/preferences/open',
+};
+
+const registerListener = (
+  endpoint: typeof ENDPOINTS[keyof typeof ENDPOINTS],
+  listener: requester.Listener
+) => {
+  requester.on(endpoint, listener);
+};
+
+export const onPreferenceOpen = (listener: requester.Listener) => {
+  registerListener(ENDPOINTS.preferencesOpen, listener);
+};
+
+export default {
+  onPreferenceOpen,
+};


### PR DESCRIPTION
### Testing

- yarn start
- from the app item in the application menu, click the `Preference...` item or `cmd + ,`
- developer console should log the event