### PR TITLE
UPDATE - until the migration step is made, we'll have to drop the tables each time the app starts in prod

### DIFF
--- a/apps/authoring/src/main/services/internal-storage/service-is.ts
+++ b/apps/authoring/src/main/services/internal-storage/service-is.ts
@@ -154,7 +154,7 @@ export const __tableCreate = (tableName: string, schema: StorageSchema) => {
 
   const isDroppable = () => {
     if (process.env.NODE_ENV !== 'development') {
-      return false; //TODO write migration step for tables when in PROD
+      return true; //TODO write migration step for tables when in PROD
     }
 
     const restart = parseInt(process.env.restart || '0');


### PR DESCRIPTION
### Short summary

- changed the table drop flag to ensure app cleanly starts in prod
