### PR TITLE
[FIX] sc-1410 UI Styling Issues

### DIFF
--- a/apps/authoring/src/renderer/components/action-menu/comp-action-menu.module.scss
+++ b/apps/authoring/src/renderer/components/action-menu/comp-action-menu.module.scss
@@ -1,0 +1,6 @@
+.action-menu {
+  &.owlui-dropdown .owlui-dropdown-toggle {
+    color: var(--bs-body-color);
+    font-size: var(--bs-btn-font-size);
+  }
+}

--- a/apps/authoring/src/renderer/components/action-menu/comp-action-menu.tsx
+++ b/apps/authoring/src/renderer/components/action-menu/comp-action-menu.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
 import { ActionMenuProps, ActionMenuItem } from './comp-action-menu.types';
+import * as styles from './comp-action-menu.module.scss';
 import {
   Dropdown,
   DropdownItemProps,
@@ -21,15 +22,13 @@ const ActionMenuBtn = (
 const makeActionMenu = (
   items: Array<ActionMenuItem>
 ): Array<DropdownItemProps> => {
+  const classes = `dropdown-item-wrapper left-pane-dropdown d-flex align-items-center`;
   return items.map(
     ({ actionHandler, label, ...props }: ActionMenuItem, idx: number) => {
       return {
         id: idx.toString(),
         label: (
-          <div
-            className="dropdown-item-wrapper left-pane-dropdown d-flex align-items-center"
-            onClick={actionHandler}
-          >
+          <div className={classes} onClick={actionHandler}>
             <Icon {...props} />
             <span>{label}</span>
           </div>
@@ -60,7 +59,13 @@ export const ActionMenu = (props: ActionMenuProps) => {
     locals
   );
 
-  return <Dropdown {...dropdownProps}></Dropdown>;
+  return (
+    <Dropdown
+      align="end"
+      className={styles.actionMenu}
+      {...dropdownProps}
+    ></Dropdown>
+  );
 };
 
 export default {

--- a/apps/authoring/src/renderer/components/action-menu/comp-action-menu.tsx
+++ b/apps/authoring/src/renderer/components/action-menu/comp-action-menu.tsx
@@ -15,7 +15,7 @@ const ActionMenuBtn = (
     display="outlined"
     filled
     icon="more_vert"
-    style={{ fontSize: '15px' }}
+    style={{ fontSize: '15px', fontWeight: 1000 }}
   />
 );
 

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
@@ -137,9 +137,9 @@
           color: inherit;
         }
 
-        & .owlui-icons {
+        & .owlui-icons-outlined {
           flex: 0 0 auto;
-          margin-right: 0.5rem;
+          margin-right: 0.875rem;
           color: var(--owl-color-default);
         }
       }

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
@@ -296,7 +296,7 @@
     }
 
     & .owlui-dropdown-toggle {
-      top: 0.6em;
+      top: 0.3em;
     }
 
     &:hover {
@@ -307,13 +307,18 @@
   &__item {
     display: flex;
     flex-grow: 1;
-    padding: 0.66rem 0.5rem 0.66rem 1.75rem;
+    padding: 3px 8px 7.92px 21px;
     margin: 0;
     line-height: 1.4;
     color: inherit;
     font-size: var(--owl-font-size-sm);
     text-decoration: none;
     text-align: left;
+
+    .module-icons,
+    .lesson-icons {
+      display: flex;
+    }
 
     &[aria-expanded='true'] {
       .tree-view__item__icon--handle {
@@ -333,7 +338,7 @@
       color: var(--owl-color-default);
 
       &--handle {
-        margin: 0;
+        margin: 4px 0 0;
         width: auto;
         height: auto;
         transform: rotate(270deg);
@@ -341,6 +346,7 @@
         align-self: baseline;
         position: absolute;
         left: 0;
+        top: 0;
         transition: transform 0.1s linear;
       }
 
@@ -349,7 +355,7 @@
         line-height: 1rem;
         font-size: 0.9rem;
         position: relative;
-        top: 0.3rem;
+        top: 0.2rem;
       }
     }
 

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
@@ -320,6 +320,11 @@
       display: flex;
     }
 
+    &:focus {
+      text-decoration: none;
+      color: currentColor;
+    }
+
     &[aria-expanded='true'] {
       .tree-view__item__icon--handle {
         transform: rotate(360deg);
@@ -348,6 +353,7 @@
         left: 0;
         top: 0;
         transition: transform 0.1s linear;
+        color: var(--bs-gray-600);
       }
 
       &--detail {
@@ -361,10 +367,6 @@
 
     &:hover {
       text-decoration: underline;
-      color: currentColor;
-    }
-
-    &:focus {
       color: currentColor;
     }
 

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.module.scss
@@ -277,6 +277,25 @@
 
 .tab-outline {
   margin-top: calc(var(--owl-sidebar-spacing) / 2);
+
+  .outline-add-module {
+    text-align: left;
+    color: var(--bs-body-color);
+    background-color: inherit;
+    padding: 5px 0 6px 22px;
+    margin: 0;
+    font-style: italic;
+    font-size: var(--bs-font-size-sm);
+    font-weight: var(--bs-body-font-weight);
+
+    .owlui-icons-outlined {
+      margin-right: 0.625rem;
+    }
+
+    &:hover {
+      background-color: var(--owl-sidebar-hover-bg);
+    }
+  }
 }
 
 .tree-view {
@@ -323,6 +342,10 @@
     &:focus {
       text-decoration: none;
       color: currentColor;
+    }
+
+    &:focus-visible {
+      border: 1px solid var(--bs-link-color);
     }
 
     &[aria-expanded='true'] {

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/editor-pane-details-outline.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/editor-pane-details-outline.tsx
@@ -2,19 +2,41 @@ import React from 'react';
 import * as styles from '../editor-pane-details.module.scss';
 import { Projects } from '../../../../../models';
 import { TreeViewModules } from './tree-view';
+import { ModuleTreeItem } from './tree-view/editor-tree-view.types';
+import { Button, Icon } from '@owlui/lib';
+import { deepCopy } from './tree-view/utils';
 
 export const TabOutline = () => {
   const project = Projects.useData();
   const tabStyles = `${styles.tabOutline} tree-view nav flex-column`;
   const handleAddModule = () => {
-    console.log('adding new module');
+    const newModule: ModuleTreeItem = {
+      name: 'Untitled Module',
+      lessons: [
+        {
+          name: 'Untitled Lesson',
+          slides: [{ name: 'Untitled Slide' }],
+        },
+      ],
+    };
+
+    const modules = deepCopy(project.modules);
+    modules.push(newModule);
+    Projects.update({ modules });
   };
 
   return (
     <div className={tabStyles}>
       <>
         <TreeViewModules tree={project.modules} project={project} />
-        <button onClick={handleAddModule}>Add Module</button>
+        <Button
+          className="outline-add-module"
+          onClick={handleAddModule}
+          variant="link"
+        >
+          <Icon icon="add" style={{ fontSize: '15px' }} />
+          <span>Add Module</span>
+        </Button>
       </>
     </div>
   );

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/editor-pane-details-resources.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/editor-pane-details-resources.tsx
@@ -81,7 +81,8 @@ const AddResourceButton = () => {
         aria-controls="addResource"
         onClick={toggleShow}
       >
-        Add a new resource to your project... <Icon icon="add_circle" />
+        Add a new resource to your project...{' '}
+        <Icon icon="attach_file" style={{ fontSize: '20px' }} />
       </Button>
       <Drawer
         drawer={resourceDrawer}

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-lessons.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-lessons.tsx
@@ -147,7 +147,7 @@ const TreeViewLesson = (props: TreeViewLessonProps) => {
               />
             </span>
             <span className={styles.treeViewItemIconDetail}>
-              <Icon icon="widgets" display="outlined" filled={open} />
+              <Icon icon="interests" display="outlined" filled={open} />
             </span>
             <span className={styles.treeViewItemLabel}>{tree.name}</span>
           </div>

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-lessons.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-lessons.tsx
@@ -139,7 +139,12 @@ const TreeViewLesson = (props: TreeViewLessonProps) => {
         >
           <div className="lesson-icons">
             <span className={styles.treeViewItemIconHandle}>
-              <Icon icon="arrow_drop_down" display="outlined" filled />
+              <Icon
+                icon="arrow_drop_down"
+                display="outlined"
+                filled
+                style={{ fontSize: '1.375rem' }}
+              />
             </span>
             <span className={styles.treeViewItemIconDetail}>
               <Icon icon="widgets" display="outlined" filled={open} />

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-modules.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-modules.tsx
@@ -174,7 +174,12 @@ const TreeViewModule = (props: TreeViewModuleProps) => {
         >
           <div className="module-icons">
             <span className={styles.treeViewItemIconHandle}>
-              <Icon icon="arrow_drop_down" display="outlined" filled />
+              <Icon
+                icon="arrow_drop_down"
+                display="outlined"
+                filled
+                style={{ fontSize: '1.375rem' }}
+              />
             </span>
             <span className={styles.treeViewItemIconDetail}>
               <Icon icon="folder" display="outlined" filled={open} />

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-slides.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/elements/tree-view/editor-tree-view-slides.tsx
@@ -123,7 +123,7 @@ const TreeViewSlide = (props: TreeViewSlideProps) => {
           onClick={handleSlideSelection}
         >
           <span className={styles.treeViewItemIconDetail}>
-            <Icon icon="check_box_outline_blank" display="outlined" filled />
+            <Icon icon="rectangle" display="outlined" />
           </span>
           <span className={styles.treeViewItemLabel}>{tree.name}</span>
         </Button>


### PR DESCRIPTION
This one took quite some time as I was trying to resolve the issues related to icon sizing and alignment of other elements that involve these icons. I will revisit these issues once OWL UI is upgraded with the latest set of icons, used in the mockup.

For quick reference, below is the list of tasks as listed in the ticket itself.
If this is merged, I will create a new ticket containing the remaining issues that needed clarification.

tabs - wrong height between modules (spacing too big)
[RESOLVED]

wrong height between 1st module and tabs
[RESOLVED]

When hovering a module title, the highlight isn't aligned
[RESOLVED]

When hovering a module title, the action menu icon isn't the same style
[RESOLVED]

The title of the 1st module is going under the folder icon
[RESOLVED]

The text for lessons is going under the lesson icon
[RESOLVED]

The icon of the lesson is wrong (both icons)
[RESOLVED]

There’s no “add new Module/Lesson/Slide” buttons
[RESOLVED IN ANOTHER BRANCH IN PROGRESS - `sc-986-outline`]

When expanding the module, the vertical line isn’t aligned with the tip of the module’s arrow pointing down
[RESOLVED]

When expanding the lesson, the vertical line isn’t aligned with the tip of the lesson’s arrow pointing down
[RESOLVED]

The icon of the slide is wrong (it’s not the right shape) and not appropriately aligned to the title of the lesson
[RESOLVED]

The arrows beside the modules and lessons titles are too big
[RESOLVED]

The arrow beside the lesson’s title, when not expanded, is showing in a different colour.
[RESOLVED]

Items have improper focus/hover underline. It currently underlines even after clicking it.
[RESOLVED]

Underlines are not valid focus states (ACCESSIBILITY)
[RESOLVED]

Look at the mockup Scott provided and notice the outline of elements when focused with tab (ACCESSIBILITY) (focus vs hover)
[RESOLVED]