### PR TITLE
FIX - temporarily hide template options in right pane

### DIFF
--- a/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane-details.module.scss
+++ b/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane-details.module.scss
@@ -1,6 +1,10 @@
 @use 'sass:selector';
 @import '@owlui/lib/src/theme/global/tokens';
 
+.owlui-nav-item:nth-child(2) {
+  display: none;
+}
+
 .template-options-content {
   padding: var(--owl-sidebar-spacing);
 }

--- a/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane-details.module.scss
+++ b/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane-details.module.scss
@@ -1,10 +1,6 @@
 @use 'sass:selector';
 @import '@owlui/lib/src/theme/global/tokens';
 
-.owlui-nav-item:nth-child(2) {
-  display: none;
-}
-
 .template-options-content {
   padding: var(--owl-sidebar-spacing);
 }

--- a/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
@@ -23,7 +23,7 @@ export const RightPane = () => {
       id: '2',
       title: 'Template Options',
       view: (
-        <div aria-hidden="true" className={styles.templateOptionsContent}>
+        <div className={styles.templateOptionsContent}>
           <p>This template does not have additional options.</p>
         </div>
       ),
@@ -36,7 +36,9 @@ export const RightPane = () => {
 
   return (
     <Pane>
-      <Tabs items={tabItems} />
+      <div className={styles.templateOptionsContent}>
+        <RightPaneContentForm activeSlide={activeSlide} />
+      </div>
     </Pane>
   );
 };

--- a/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
@@ -23,7 +23,7 @@ export const RightPane = () => {
       id: '2',
       title: 'Template Options',
       view: (
-        <div className={styles.templateOptionsContent}>
+        <div aria-hidden="true" className={styles.templateOptionsContent}>
           <p>This template does not have additional options.</p>
         </div>
       ),


### PR DESCRIPTION
### Short summary

Because this is temporary, I just made a rule for display: none and and added an aria-hidden attribute--if this is insufficient, we can just remove the html entirely and bring it back later.

---

### Test steps

1.
1.
1.
