### PR TITLE
FIX - Small Style items

### DIFF
--- a/apps/authoring/src/main/assets/template-introduction/manifest.json
+++ b/apps/authoring/src/main/assets/template-introduction/manifest.json
@@ -4,7 +4,7 @@
     "aspect": "16:9"
   },
   "meta": {
-    "name": "introduction",
+    "name": "Introduction",
     "filename": "introduction",
     "component": "Introduction"
   },

--- a/apps/authoring/src/main/assets/template-two-columns/manifest.json
+++ b/apps/authoring/src/main/assets/template-two-columns/manifest.json
@@ -4,7 +4,7 @@
     "aspect": "16:9"
   },
   "meta": {
-    "name": "two columns",
+    "name": "Two Columns",
     "filename": "two-columns",
     "component": "TwoColumns"
   },

--- a/apps/authoring/src/main/assets/workspace/canvas.html.hbs
+++ b/apps/authoring/src/main/assets/workspace/canvas.html.hbs
@@ -19,7 +19,7 @@
   <script type="module" src="{{data.canvasJs}}"></script>
 </head>
 <body>
-  <div id="app">Hello World</div>
+  <div id="app"></div>
 </body>
 </html>
 {{/with}}

--- a/apps/authoring/src/renderer/components/pane/comp-pane.module.scss
+++ b/apps/authoring/src/renderer/components/pane/comp-pane.module.scss
@@ -3,30 +3,34 @@
 @import '@owlui/lib/src/theme/global/tokens';
 
 .pane {
-  &--left,
-  &--right {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    flex-shrink: 0;
-    min-width: $owl-sys-size-sidebar-minwidth;
-    width: $owl-sys-size-sidebar-width;
-    color: var(--owl-sidebar-color);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+  min-width: $owl-sys-size-sidebar-minwidth;
+  width: $owl-sys-size-sidebar-width;
+  color: var(--owl-sidebar-color);
+  background: var(--owl-sidebar-bg);
+  padding-top: 0.5rem;
+
+  &__header {
+    flex: 0 1 auto;
+    margin-top: calc($owl-sys-space-sidebar / 2);
+  }
+
+  &__content {
+    flex: 1 1 auto;
+    padding-bottom: $owl-sys-space-sidebar;
+    overflow-y: auto;
+  }
+
+  &--left {
     border-right: var(--owl-border-width) var(--owl-border-color) solid;
-    background: var(--owl-sidebar-bg);
-    padding-top: 0.5rem;
+  }
 
-    &__header {
-      flex: 0 1 auto;
-      margin-top: calc($owl-sys-space-sidebar / 2);
-    }
-
-    &__content {
-      flex: 1 1 auto;
-      padding-bottom: $owl-sys-space-sidebar;
-      overflow-y: auto;
-    }
+  &--right {
+    border-left: var(--owl-border-width) var(--owl-border-color) solid;
   }
 
   &__heading {
@@ -48,5 +52,60 @@
 
   .owlui-tab-pane {
     font-size: $owl-ref-typeface-size-xs;
+  }
+}
+
+.grabhandle {
+  position: absolute;
+  z-index: 2;
+  width: $owl-sys-size-grabhandle;
+  border-width: 0 1px 0 1px;
+  border-style: solid;
+  border-color: transparent;
+  top: 0;
+  bottom: 0;
+  cursor: col-resize;
+
+  > div {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: calc($owl-sys-size-grabhandle-hover / -2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 0;
+    overflow: hidden;
+    background: var(--owl-border-color);
+    transition-duration: 0.1s;
+    transition-delay: 0.2s;
+    transition-timing-function: $owl-ref-style-cubic-bezier;
+    transition-property: opacity;
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    > div {
+      opacity: 1;
+      width: $owl-sys-size-grabhandle-hover;
+    }
+  }
+
+  &:active {
+    > div {
+      color: var(--owl-active-color);
+      background: var(--owl-active-bg);
+    }
+  }
+
+  &--left {
+    right: -1px;
+  }
+
+  &--right {
+    left: -1px;
   }
 }

--- a/apps/authoring/src/renderer/pages/editor/elements/header/elements/header-preview-button.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/header/elements/header-preview-button.tsx
@@ -5,7 +5,8 @@ import * as styles from '../editor-header.module.scss';
 export const PreviewButton = ({ disabled }: { disabled: boolean }) => {
   return (
     <Button
-      className={`btn btn-sm btn-ghost-primary ${styles.btnPreview}`}
+      className={`btn-ghost-primary ${styles.btnPreview}`}
+      size="sm"
       disabled={disabled}
     >
       <Icon icon="interests" />

--- a/apps/authoring/src/renderer/pages/editor/elements/header/elements/header-publish-button.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/header/elements/header-publish-button.tsx
@@ -12,7 +12,9 @@ export const PublishButton = ({ disabled }: { disabled: boolean }) => {
   return (
     <>
       <Button
-        className={`btn btn-sm btn-primary ms-3 ${styles.btnPublish}`}
+        className={`ms-3 ${styles.btnPublish}`}
+        variant="primary"
+        size="sm"
         onClick={toggleShowDrawer}
         disabled={disabled}
       >

--- a/apps/authoring/src/renderer/pages/editor/elements/header/elements/header-publish-drawer.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/header/elements/header-publish-drawer.tsx
@@ -55,7 +55,9 @@ export const PublishDrawer = (props: PublishDrawerProps) => {
         <PublishDrawerContent project={project} />
         <div className="d-flex justify-content-end my-3">
           <Button
-            className={`btn btn-sm btn-success ms-2 ${styles.btnPublish}`}
+            className={`ms-2 ${styles.btnPublish}`}
+            size="sm"
+            variant="success"
             onClick={handlePublish}
             disabled={props.disabled}
           >

--- a/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/pane-details/editor-pane-details.tsx
@@ -30,7 +30,7 @@ export const PaneDetails = () => {
 
   return (
     <Pane>
-      <Tabs items={tabItems} pxScale="Sm" />
+      <Tabs items={tabItems} pxScale="Sm" transition={false} />
     </Pane>
   );
 };

--- a/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
@@ -46,7 +46,9 @@ export const RightPane = () => {
           <Icon icon="dashboard" display="sharp" filled={true} />
         </span>
         <div>
-          <div className={styles.slideEditorHeaderTitle}>{slideData.name}</div>
+          <div className={styles.slideEditorHeaderTitle}>
+            {activeSlide.template.meta.name}
+          </div>
           <Button
             className={styles.slideEditorHeaderAction}
             variant="link"

--- a/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
+++ b/apps/authoring/src/renderer/pages/editor/elements/right-pane/editor-right-pane.tsx
@@ -47,7 +47,7 @@ export const RightPane = () => {
         </span>
         <div>
           <div className={styles.slideEditorHeaderTitle}>
-            {activeSlide.template.meta.name}
+            {slideData.template.meta.name}
           </div>
           <Button
             className={styles.slideEditorHeaderAction}

--- a/apps/authoring/src/renderer/pages/settings/page-settings.tsx
+++ b/apps/authoring/src/renderer/pages/settings/page-settings.tsx
@@ -33,7 +33,7 @@ export const PageElement = () => {
             Settings
           </h1>
         </div>
-        <Tabs defaultActiveKey="theme">
+        <Tabs defaultActiveKey="theme" transition={false}>
           <Tab eventKey="theme" title="Theme">
             <Pages.Theme.Element />
           </Tab>


### PR DESCRIPTION
### Short summary
A few items to do with styles.
- Remove transition on tabs. instant tab switching feels more responsive.
- remove "Hello World" from the canvas so it doesn't ever flash on the screen.
- Right Pane was showing the current slide title rather than the current selected template name in the template section.
  <img width="210" alt="image" src="https://user-images.githubusercontent.com/4621427/192542302-fa868d94-c88c-4f54-8e03-35e966f0aff8.png">
- Give Right and left pane different border styles
- Add the grabhandle styling to the pane stylesheet (leave it off the template until it is implemented.)

