### PR TITLE
SC-1567-top-bar-qa-owl-icon

### DIFF
--- a/apps/authoring/src/renderer/components/logo/comp-logo.module.scss
+++ b/apps/authoring/src/renderer/components/logo/comp-logo.module.scss
@@ -1,4 +1,5 @@
 .logo {
+  margin-left: .4rem;
   svg {
     fill: #002a6a; // var(--bs-secondary) doesn't match Scott's design
     filter: drop-shadow(0px 0px 1px var(--bs-white));


### PR DESCRIPTION

### Short summary

- added minor margin to the left of the logo to be in line with left pane tabs

